### PR TITLE
Fix migration error

### DIFF
--- a/stubs/migrations/create_online_mailables_table.php.stub
+++ b/stubs/migrations/create_online_mailables_table.php.stub
@@ -17,7 +17,7 @@ class CreateOnlineMailablesTable extends Migration
             $table->id();
             $table->uuid('uuid');
             $table->timestamps();
-            $table->timestamp('expires_at');
+            $table->timestamp('expires_at')->nullable();
             $table->binary('content');
         });
     }


### PR DESCRIPTION
Hi, 
First of all, I would like to thank you for your great work @Sammyjo20 :+1: 
I tried to install your package, but I encountered a slight problem during the migration of the table. So I decided to propose a simple improvement, so that everyone can install this package without encountering any error from the beginning.

My problem was this one: 
```
SQLSTATE[42000]: Syntax error or access violation: 1067 Invalid default value for 'expires_at' (SQL: create table `online_mailables` (`id` bigint unsigned not null auto_increment primary key, `uuid` char(36) not null, `created_at` timestamp null, `updated_at` timestamp null, `expires_at` timestamp not null, `content` blob not null) default character set utf8mb4 collate 'utf8mb4_unicode_ci')
```
Just set "expires_at" nullable fix it.

Thanks again for your work,
See ya!