### PR TITLE
Add tests for DeleteExpiredMailable Command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
     },
     "autoload-dev": {
         "psr-4": {
+            "Database\\Factories\\": "database/factories",
             "Sammyjo20\\Wagonwheel\\Tests\\": "tests"
         }
     },

--- a/composer.json
+++ b/composer.json
@@ -32,5 +32,14 @@
         "psr-4": {
             "Sammyjo20\\Wagonwheel\\": "src/"
         }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Sammyjo20\\Wagonwheel\\Tests\\": "tests"
+        }
+    },
+    "require-dev": {
+        "orchestra/testbench": "^6.0",
+        "phpunit/phpunit": "^9.4"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -42,5 +42,9 @@
     "require-dev": {
         "orchestra/testbench": "^6.0",
         "phpunit/phpunit": "^9.4"
+    },
+    "scripts": {
+        "test": "vendor/bin/phpunit",
+        "test-f": "vendor/bin/phpunit --filter"
     }
 }

--- a/database/factories/OnlineMailableFactory.php
+++ b/database/factories/OnlineMailableFactory.php
@@ -24,15 +24,13 @@ class OnlineMailableFactory extends Factory
 
     public function expired()
     {
-        return $this->state([
-            'expires_at' => Carbon::parse('1 year ago'),
-        ]);
+        return $this->expiresIn(now()->subYear());
     }
 
-    public function expiresIn(string $expirePeriod)
+    public function expiresIn(Carbon $date)
     {
         return $this->state([
-            'expires_at' => now()->add($expirePeriod),
+            'expires_at' => $date,
         ]);
     }
 }

--- a/database/factories/OnlineMailableFactory.php
+++ b/database/factories/OnlineMailableFactory.php
@@ -21,4 +21,18 @@ class OnlineMailableFactory extends Factory
             'content' => $this->faker->sentence(6),
         ];
     }
+
+    public function expired()
+    {
+        return $this->state([
+            'expires_at' => Carbon::parse('1 year ago'),
+        ]);
+    }
+
+    public function expiresIn(string $expirePeriod)
+    {
+        return $this->state([
+            'expires_at' => now()->add($expirePeriod),
+        ]);
+    }
 }

--- a/database/factories/OnlineMailableFactory.php
+++ b/database/factories/OnlineMailableFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Sammyjo20\Wagonwheel\Models\OnlineMailable;
+
+
+class OnlineMailableFactory extends Factory
+{
+    protected $model = OnlineMailable::class;
+
+    public function definition()
+    {
+        $expiration = config('wagonwheel.message_expires_in_days', 30);
+
+        return [
+            'uuid' => $this->faker->uuid,
+            'expires_at' => Carbon::now()->addDays($expiration),
+            'content' => $this->faker->sentence(6),
+        ];
+    }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <env name="DB_CONNECTION" value="testing"/>
+  </php>
+</phpunit>

--- a/readme.md
+++ b/readme.md
@@ -83,6 +83,19 @@ If you would like to customise how the banner looks inside the email, just publi
 php artisan vendor:publish --tag=wagonwheel-views
 ```
 
+## Testing
+Run all tests
+
+```
+composer test
+```
+
+Run a specific test
+
+```
+composer test-f [name of test method]
+```
+
 ## Thanks
 - Ryan Chandler (@ryangjchandler) helped out massively with some great code improvements and overall making Wagonwheel better!
 - Gareth Thompson (@cssgareth) helped out with coming up with a cool name!

--- a/src/Models/OnlineMailable.php
+++ b/src/Models/OnlineMailable.php
@@ -2,11 +2,20 @@
 
 namespace Sammyjo20\Wagonwheel\Models;
 
+use Database\Factories\OnlineMailableFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class OnlineMailable extends Model
 {
+    use HasFactory;
+
     protected $casts = [
         'expires_at' => 'timestamp',
     ];
+
+    protected static function newFactory()
+    {
+        return new OnlineMailableFactory;
+}
 }

--- a/tests/Commands/DeleteExpiredMailablesTest.php
+++ b/tests/Commands/DeleteExpiredMailablesTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Sammyjo20\Wagonwheel\Tests\Commands;
+
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Sammyjo20\Wagonwheel\Commands\DeleteExpiredMailables;
+use Sammyjo20\Wagonwheel\Models\OnlineMailable;
+use Sammyjo20\Wagonwheel\Tests\TestCase;
+
+class DeleteExpiredMailablesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    function it_deletes_a_mailable_when_it_is_expired()
+    {
+        // The online mailable will expire after 15 days
+        Config::set('wagonwheel.message_expires_in_days', 15);
+
+        OnlineMailable::factory()->create();
+
+        $this->assertCount(1, OnlineMailable::all());
+
+        // After 14 days, the mailable should not be deleted
+        $this->travel(14)->days();
+        $this->deleteExpiredMailables();
+        $this->assertCount(1, OnlineMailable::all());
+
+        // After 15 days, the mailable should be deleted
+        $this->travel(1)->days();
+        $this->deleteExpiredMailables();
+        $this->assertCount(0, OnlineMailable::all());
+    }
+
+    /** @test */
+    function it_only_deletes_expired_mailables()
+    {
+        $expiredMailable = OnlineMailable::factory()->expired()->create();
+        $nonExpiredMailable = OnlineMailable::factory()->expiresIn('30 days')->create();
+
+        $this->assertCount(2, OnlineMailable::all());
+        $this->assertDatabaseHas('online_mailables', ['uuid' => $expiredMailable->uuid]);
+        $this->assertDatabaseHas('online_mailables', ['uuid' => $nonExpiredMailable->uuid]);
+
+        $this->deleteExpiredMailables();
+
+        $this->assertCount(1, OnlineMailable::all());
+
+        $this->assertDatabaseHas('online_mailables', ['uuid' => $nonExpiredMailable->uuid]);
+        $this->assertDatabaseMissing('online_mailables', ['uuid' => $expiredMailable->uuid]);
+    }
+
+    private function deleteExpiredMailables()
+    {
+        $this->artisan(DeleteExpiredMailables::class)
+            ->expectsOutput('Successfully deleted expired online mailables ✅')
+            ->assertExitCode(0);
+    }
+}

--- a/tests/Commands/DeleteExpiredMailablesTest.php
+++ b/tests/Commands/DeleteExpiredMailablesTest.php
@@ -2,7 +2,6 @@
 
 namespace Sammyjo20\Wagonwheel\Tests\Commands;
 
-use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Config;
 use Sammyjo20\Wagonwheel\Commands\DeleteExpiredMailables;
@@ -38,7 +37,7 @@ class DeleteExpiredMailablesTest extends TestCase
     function it_only_deletes_expired_mailables()
     {
         $expiredMailable = OnlineMailable::factory()->expired()->create();
-        $nonExpiredMailable = OnlineMailable::factory()->expiresIn('30 days')->create();
+        $nonExpiredMailable = OnlineMailable::factory()->expiresIn(now()->addMonth())->create();
 
         $this->assertCount(2, OnlineMailable::all());
         $this->assertDatabaseHas('online_mailables', ['uuid' => $expiredMailable->uuid]);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Sammyjo20\Wagonwheel\Tests;
+
+use Sammyjo20\Wagonwheel\WagonwheelServiceProvider;
+
+class TestCase extends \Orchestra\Testbench\TestCase
+{
+    protected function getPackageProviders($app)
+    {
+        return [
+            WagonwheelServiceProvider::class,
+        ];
+    }
+
+    public function getEnvironmentSetUp($app)
+    {
+        // import the CreatePostsTable class from the migration
+        include_once __DIR__ . '/../stubs/migrations/create_online_mailables_table.php.stub';
+
+        // run the up() method of that migration class
+        (new \CreateOnlineMailablesTable)->up();
+    }
+}


### PR DESCRIPTION
This PR adds a test for the `DeleteExpiredMailable` command and asserts that it can succesfully delete expired mailables, but does not delete non-expired mailables.

@Sammyjo20 in my next PR, I'll write a test for the feature I'm working on, to allow users to store mailables indefinitely.

This PR is dependent on #6 (which should be merged first).